### PR TITLE
Docs: Fix UI broken

### DIFF
--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -84,43 +84,36 @@ Debugging your extension in [Visual Studio Online](https://aka.ms/vso) preview c
 <!-- Follow these steps:-->
 
 1. [Visual Studio Online 익스텐션을 설치](https://aka.ms/vso-docs/vscode)하고 가입하십시오
-<!--
-1. Install the [Visual Studio Online extension and sign in](https://aka.ms/vso-docs/vscode). -->
 
 2. 새 [클라우드 호스팅 작업 환경](https://aka.ms/vso-docs/vscode/cloud-hosted) (유료)을 생성하거나 여러분의 데스크톱을 [셀프 호스팅 작업환경](https://aka.ms/vso-docs/vscode/self-hosted)으로 등록 하십시오(무료). 
-
-<!--
-2. Create a new managed [cloud-hosted environment](https://aka.ms/vso-docs/vscode/cloud-hosted) (paid) or register your own desktop as a [self-hosted environment](https://aka.ms/vso-docs/vscode/self-hosted) (free).-->
-
-
-    > **주의:** 셀프 호스팅 작업 환경을 사용하는 경우 버그로 인해 재시작이나 네트워크 오류 발생시 작업 환경을 복원을 위해 **VS Online: Restore Local Environment** 커맨드를 사용해야 할 수도 있습니다. 자세한 내용은 [MicrosoftDocs/vsonline#5](https://github.com/MicrosoftDocs/vsonline/issues/5), [MicrosoftDocs/vsonline#14](https://github.com/MicrosoftDocs/vsonline/issues/14)을 참조하십시오. 
-    
-<!--
-    > **Note:** When using a self-hosted environment, you may have to restore your environment on restart or after a network glitch using the **VS Online: Restore Local Environment** command due to bugs. See [MicrosoftDocs/vsonline#5](https://github.com/MicrosoftDocs/vsonline/issues/5), [MicrosoftDocs/vsonline#14](https://github.com/MicrosoftDocs/vsonline/issues/14) for more information.-->
-
+   > **주의:** 셀프 호스팅 작업 환경을 사용하는 경우 버그로 인해 재시작이나 네트워크 오류 발생시 작업 환경을 복원을 위해 **VS Online: Restore Local Environment** 커맨드를 사용해야 할 수도 있습니다. 자세한 내용은 [MicrosoftDocs/vsonline#5](https://github.com/MicrosoftDocs/vsonline/issues/5), [MicrosoftDocs/vsonline#14](https://github.com/MicrosoftDocs/vsonline/issues/14)을 참조하십시오. 
 3. 환경에 연결되지 않았다면, VS Code의 Command Palette(`kbstyle(F1)`)에서 **VS Online: Connect to Environment**를 선택하여 연결하십시오. 
-
-<!-- 3. If you have not already connected to your environment, select  **VS Online: Connect to Environment** from the Command Palette (`kbstyle(F1)`) in VS Code to connect. -->
 
 4. 연결 된 이후에, **File > Open... / Open Folder...** 를 사용하여 익스텐션 소스 코드가 위치한 작업 공간 폴더를 선택하거나, Command Palette (`kbstyle(F1)`)에서 **Git: Clone**를 선택하여 환경에 클론한 다음 여십시오.
 
-<!--
-4. Once connected, either use **File > Open... / Open Folder...** to select the environment folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it into the environment and open it. -->
-
 5. VS Online의 클라우드 기반 환경이 대부분의 익스텐션의 요구사항을 충족 하지만, 다른 필요 디펜던시를 (예를 들어 `yarn install`이나 `apt-get`을 사용하여 ) 새 VS Code 터미널 창 (`kb(workbench.action.terminal.new)`) 에서  설치 할 수 있습니다. 
-
-<!--
-5. While VS Online's cloud-based environments should have all the needed prerequisites for most extensions, you can install any other required dependencies (for example using `yarn install` or `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`). -->
 
 6. 마지막으로, `kb(workbench.action.debug.start)`를 누르거나 **Debug view**를 사용하여 Visual Studio Online 환경 내에서 익스텐션을 실행 하십시오. 
 
-<!--
-6. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside in the Visual Studio Online environment. -->
-
-    > **주의:** 표시되는 창에서 익스텐션의 소스 코드 폴더를 열 수는 없지만, 환경의 하위 폴더나 다른 곳을 열 수 있습니다. 
+   > **주의:** 표시되는 창에서 익스텐션의 소스 코드 폴더를 열 수는 없지만, 환경의 하위 폴더나 다른 곳을 열 수 있습니다. 
 
 <!--
-    > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the environment. -->
+1. Install the [Visual Studio Online extension and sign in](https://aka.ms/vso-docs/vscode).
+
+2. Create a new managed [cloud-hosted environment](https://aka.ms/vso-docs/vscode/cloud-hosted) (paid) or register your own desktop as a [self-hosted environment](https://aka.ms/vso-docs/vscode/self-hosted) (free).
+
+    > **Note:** When using a self-hosted environment, you may have to restore your environment on restart or after a network glitch using the **VS Online: Restore Local Environment** command due to bugs. See [MicrosoftDocs/vsonline#5](https://github.com/MicrosoftDocs/vsonline/issues/5), [MicrosoftDocs/vsonline#14](https://github.com/MicrosoftDocs/vsonline/issues/14) for more information.
+
+3. If you have not already connected to your environment, select  **VS Online: Connect to Environment** from the Command Palette (`kbstyle(F1)`) in VS Code to connect.
+
+4. Once connected, either use **File > Open... / Open Folder...** to select the environment folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it into the environment and open it.
+
+5. While VS Online's cloud-based environments should have all the needed prerequisites for most extensions, you can install any other required dependencies (for example using `yarn install` or `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`).
+
+6. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside in the Visual Studio Online environment.
+
+  > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the environment. 
+-->
 
 나타나는 익스텐션 개발 호스트 창에는 디버거가 연결된 VS Online 환경에서 실행중인 익스텐션이 포함 될 것입니다. 
 
@@ -146,37 +139,34 @@ The extension development host window that appears will include your extension r
 Follow these steps: -->
 
 1. [원격 - 컨테이너 익스텐션을 설치, 구성](/docs/remote/containers#_getting-started) 한 다음, **File > Open... / Open Folder...** 를 사용하여 로컬 VS Code에서 소스 코드를 여십시오. 
-<!--
-1. After [installing and configuring the Remote - Containers extension](/docs/remote/containers#_getting-started), use **File > Open... / Open Folder...** to open your source code locally in VS Code.-->
 
 2. Command Palette (`kbstyle(F1)`)에서 **Remote-Containers: Add Development Container Configuration Files...** 를 선택하고, **Node.js 8 & TypeScript** (타입스크립트를 사용 하지 않는 경우 Node.js 8)를 골라 필요한 컨테이너 구성 파일을 추가 하십시오. 
 
-<!--
-2. Select **Remote-Containers: Add Development Container Configuration Files...** from the Command Palette (`kbstyle(F1)`), and pick **Node.js 8 & TypeScript** (or Node.js 8 if you are not using TypeScript) to add the needed container configuration files.-->
-
 3. **[선택]** 이 커맨드의 실행 후, `.devcontainer` 폴더의 내용을 수정하여 추가 빌드 혹은 런타임 요구사항을 포함 시킬 수 있습니다. [원격 - 컨테이너](/docs/remote/containers#_indepth-setting-up-a-folder-to-run-in-a-container)문서를 통해 자세한 내용을 확인 하십시오.
-
-<!--
-3. **[Optional]** After this command runs, you can modify the contents of the `.devcontainer` folder to include additional build or runtime requirements. See the in-depth [Remote - Containers](/docs/remote/containers#_indepth-setting-up-a-folder-to-run-in-a-container) documentation for details. -->
 
 4. **Remote-Containers: Reopen Folder in Container**를 실행한뒤, VS Code는 컨테이너를 설정하고 연결 할 것입니다. 이제 로컬에서와 동일하게 소스 코드를 컨테이너에서 개발 할 수 있습니다. 
 
-<!--
-4. Run **Remote-Containers: Reopen Folder in Container** and in a moment, VS Code will set up the container and connect. You will now be able to develop your source code from inside the container just as you would in the local case.-->
-
 5. `yarn install` 이나 `npm install`를 새 VS Code 터미널 창 (`kb(workbench.action.terminal.new)`)에서 실행하여 Linux 버전의 Node.js 의존성이 설치 되게 하십시오. 다른 OS나 런타임 의존성을 설치 할 수 있지만, 이를 `.devcontainer/Dockerfile`에도 추가하여 컨테이너를 다시 빌드 했을때도 사용 가능하게 할 수 있습니다.
-
-<!--
-5. Run `yarn install` or `npm install` in a new VS Code terminal window (`kb(workbench.action.terminal.new)`) to ensure the Linux versions Node.js native dependencies are install. You can also install other OS or runtime dependencies, but you may want to add these to `.devcontainer/Dockerfile` as well so they are available if you rebuild the container. -->
 
 6. 마지막으로 `kb(workbench.action.debug.start)`를 누르거나, **Debug view**를 사용하여 동일한 컨테이너내에서 익스텐션을 실행하고 디버거를 연결하십시오. 
 
 <!--
-6. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside this same container and attach the debugger. -->
+1. After [installing and configuring the Remote - Containers extension](/docs/remote/containers#_getting-started), use **File > Open... / Open Folder...** to open your source code locally in VS Code.
 
-    > **주의:** 표시되는 창에서 익스텐션의 소스 코드 폴더를 열 수는 없지만, 환경의 하위 폴더나 다른 곳을 열 수 있습니다. 
-<!--
-    > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the container. -->
+2. Select **Remote-Containers: Add Development Container Configuration Files...** from the Command Palette (`kbstyle(F1)`), and pick **Node.js 8 & TypeScript** (or Node.js 8 if you are not using TypeScript) to add the needed container configuration files.
+
+3. **[Optional]** After this command runs, you can modify the contents of the `.devcontainer` folder to include additional build or runtime requirements. See the in-depth [Remote - Containers](/docs/remote/containers#_indepth-setting-up-a-folder-to-run-in-a-container) documentation for details.
+
+4. Run **Remote-Containers: Reopen Folder in Container** and in a moment, VS Code will set up the container and connect. You will now be able to develop your source code from inside the container just as you would in the local case.
+
+5. Run `yarn install` or `npm install` in a new VS Code terminal window (`kb(workbench.action.terminal.new)`) to ensure the Linux versions Node.js native dependencies are install. You can also install other OS or runtime dependencies, but you may want to add these to `.devcontainer/Dockerfile` as well so they are available if you rebuild the container.
+
+6. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside this same container and attach the debugger. 
+
+   > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else in the container. -->
+
+   > **주의:** 표시되는 창에서 익스텐션의 소스 코드 폴더를 열 수는 없지만, 환경의 하위 폴더나 다른 곳을 열 수 있습니다. 
+
     
 나타나는 익스텐션 개발 호스트 창에는 2번째 단계에서 정의한 컨테이너에서 디버거가 연결된 익스텐션이 포함됩니다.
 
@@ -194,27 +184,25 @@ The extension development host window that appears will include your extension r
 Follow steps: -->
 
 1. [원격 - SSH 익스텐션을 설치, 구성](/docs/remote/ssh#_getting-started) 한 이후에, VS Code의 Command Palette (`kbstyle(F1)`)에서 **Remote-SSH: Connect to Host...** 를 선택하여 호스트에 연결하십시오. 
-<!--
-1. After [installing and configuring the Remote - SSH extension](/docs/remote/ssh#_getting-started), select **Remote-SSH: Connect to Host...** from the Command Palette (`kbstyle(F1)`) in VS Code to connect to a host.-->
 
 2. 연결되고 나면, **File > Open... / Open Folder...** 중 하나를 사용하여 익스텐션 소스 코드가 포함된 원격 폴더를 선택하거나 Command Palette (`kbstyle(F1)`)에서 **Git: Clone**을 선택, 클론하여 원격 호스트에서 여십시오.
 
-<!--
-2. Once connected, either use **File > Open... / Open Folder...** to select the remote folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it and open it on the remote host. -->
-
 3. 새 VS Code 터미널 창에서 설치되지 않은 의존성 패키지를 (예를 들어 `yarn install` 이나 `apt-get`을 이용하여) 설치 하십시오. 
-
-<!--
-3. Install any required dependencies that might be missing (for example using `yarn install` or `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`).-->
 
 4. 마지막으로, `kb(workbench.action.debug.start)`를 누르거나 **디버그 뷰**를 사용하여 원격 호스트에서 익스텐션을 시작하고 디버거를 연결 하십시오. 
 
-<!--
-4. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside on the remote host and attach the debugger. -->
-
     > **주의:** 표시되는 창에서 익스텐션의 소스 코드 폴더를 열 수는 없지만, 환경의 하위 폴더나 다른 곳을 열 수 있습니다. 
 
-    <!-- > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else on the SSH host.-->
+<!--
+1. After [installing and configuring the Remote - SSH extension](/docs/remote/ssh#_getting-started), select **Remote-SSH: Connect to Host...** from the Command Palette (`kbstyle(F1)`) in VS Code to connect to a host.
+
+2. Once connected, either use **File > Open... / Open Folder...** to select the remote folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it and open it on the remote host. 
+
+3. Install any required dependencies that might be missing (for example using `yarn install` or `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`).
+
+4. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension inside on the remote host and attach the debugger.
+
+     > **Note:** You will not be able to open the extension source code folder in the window that appears, but you can open a sub-folder or somewhere else on the SSH host.-->
 
 나타나는 익스텐션 개발 호스트 창에는 디버거가 연결된 SSH 호스트에서 실행중인 익스텐션이 포함되어 있습니다. 
 
@@ -232,26 +220,24 @@ Follow these steps: -->
 
 1. [원격 - WSL 익스텐션 설치 및 구성](/docs/remote/wsl) 이후, VS Code의 Command Palette (`kbstyle(F1)`)에서 **Remote-WSL: New Window**를 선택하십시오. 
 
-<!--
-1. After [installing and configuring the Remote - WSL extension](/docs/remote/wsl), select **Remote-WSL: New Window** from the Command Palette (`kbstyle(F1)`) in VS Code.-->
-
 2. 나타나는 새 창에서, **File > Open... / Open Folder...** 를 사용하여 익스텐션 소스코드가 포함된 원격 폴더를 선택하거나, Command Palette (`kbstyle(F1)`)에서 **Git: Clone** 를 사용하여 클론한뒤 WSL에서 여십시오. 
-
-<!--
-2. In the new window that appears, either use **File > Open... / Open Folder...** to select the remote folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it and open it in WSL. -->
 
     > **팁:** `/mnt/c` 폴더를 선택하여 윈도우쪽에서 클론된 소스코드에 액세스 할 수 있습니다. 
 
-    <!-- > **Tip:** You can select the `/mnt/c` folder to access any cloned source code you have on the Windows side. -->
-
 3. 새 VS Code 터미널 창(`kb(workbench.action.terminal.new)`)에서 필요한 의존성 패키지 (예로 `apt-get`을 사용하여) 를 설치하십시오. 리눅스 버전의 Node.js 의존성을 사용하기 위해 최소한 `yarn install`이나 `npm install`을 설치해야 할 것입니다.
-
-<!--
-3. Install any required dependencies that might be missing (for example using `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`). You will at least want to run `yarn install` or `npm install` to ensure Linux versions of native Node.js dependencies are available. -->
 
 4. 마지막으로, `kb(workbench.action.debug.start)`를 누르거나 **디버그 뷰**를 사용하여, 익스텐션을 실행하고 디버거를 로컬에서와 같이 연결하십시오. 
 
 <!--
+1. After [installing and configuring the Remote - WSL extension](/docs/remote/wsl), select **Remote-WSL: New Window** from the Command Palette (`kbstyle(F1)`) in VS Code.
+
+2. In the new window that appears, either use **File > Open... / Open Folder...** to select the remote folder with your extension source code in it or select **Git: Clone** from the Command Palette (`kbstyle(F1)`) to clone it and open it in WSL.
+
+
+   > **Tip:** You can select the `/mnt/c` folder to access any cloned source code you have on the Windows side.
+
+3. Install any required dependencies that might be missing (for example using `apt-get`) in a new VS Code terminal window (`kb(workbench.action.terminal.new)`). You will at least want to run `yarn install` or `npm install` to ensure Linux versions of native Node.js dependencies are available.
+
 4. Finally, press `kb(workbench.action.debug.start)` or use the **Debug view** to launch the extension and attach the debugger as you would locally. -->
 
     > **주의:** 나타나는 창에서 익스텐션 소스 코드 폴더를 열 수는 없지만 하위 폴더나 다른 WSL의 다른 곳을 열 수 있습니다. 

--- a/api/advanced-topics/remote-extensions.md
+++ b/api/advanced-topics/remote-extensions.md
@@ -1100,7 +1100,7 @@ If your extension is purely written in JavaScript/TypeScript, you may not need t
 <!--
 However, if your extension works on Debian 9+, Ubuntu 16.04+, or RHEL / CentOS 7+ remote SSH hosts, containers, or WSL, but fails on supported non-x86_64 hosts (for example ARMv7l) or Alpine Linux containers, the extension may include x86_64 `glibc` specific native code or runtimes that will fail on these architectures/operating systems.-->
 
-예를 들어, 익스텐션은 네이티브 모듈 혹은 런타임의 x86_64 컴파일 버전만 포함 할 수 있습니다. Alpine Linux의 경우 포함된 네이티브 코드 또는 런타임이  `libc`가 Alpine Linux (`musl`)과 다른 배포판에서 (`glibc`) 구현된 [기본적 차이]https://wiki.musl-libc.org/functional-differences-from-glibc.html)에 따라 작동 하지 않을 수 있습니다. 
+예를 들어, 익스텐션은 네이티브 모듈 혹은 런타임의 x86_64 컴파일 버전만 포함 할 수 있습니다. Alpine Linux의 경우 포함된 네이티브 코드 또는 런타임이  `libc`가 Alpine Linux (`musl`)과 다른 배포판에서 (`glibc`) 구현된 [기본적 차이](https://wiki.musl-libc.org/functional-differences-from-glibc.html)에 따라 작동 하지 않을 수 있습니다. 
 
 <!--
 For example, your extension may only include x86_64 compiled versions of native modules or runtimes. For Alpine Linux, the included native code or runtimes may not work due to [fundamental differences](https://wiki.musl-libc.org/functional-differences-from-glibc.html) between how `libc` is implemented in Alpine Linux (`musl`) and other distributions (`glibc`).-->

--- a/api/extension-guides/debugger-extension.md
+++ b/api/extension-guides/debugger-extension.md
@@ -448,13 +448,7 @@ Since VS Code runs on different platforms, we have to make sure that the DA prog
 
 1. 프로그램이 플랫폼 독립적으로 구현된경우, 예를 들어 모든 플랫폼을 지원하는 런타임에서 돌아가는 경우, **runtime** 속성에 이 런타임을 명시하십시오. 현재 VS Code는 `node`와 `mono` 런타임을 지원합니다. 위의 연습용 debug adapter가 이 방식을 사용합니다.
 
-<!--
-1. If the program is implemented in a platform independent way, e.g. as program that runs on a runtime that is available on all supported platforms, you can specify this runtime via the **runtime** attribute. As of today, VS Code supports `node` and `mono` runtimes. Our Mock debug adapter from above uses this approach. -->
-
 1. 여러분의 DA 구현이 다른 플랫폼에서 다른 실행 방식을 필요하는 경우, 아래와 같이 **program** 속성을 통해 설정하십시오. 
-
-<!--
-1. If your DA implementation needs different executables on different platforms, the **program** attribute can be qualified for specific platforms like this: -->
 
    ```json
    "debuggers": [{
@@ -473,8 +467,40 @@ Since VS Code runs on different platforms, we have to make sure that the DA prog
 
 1. 위의 방식들을 조합 하는 것 또한 가능합니다. 아래의 예시는 Mono DA의 것으로 macOS와 Linux에서는 런타임을 필요로 하는 mono 어플리케이션으로 구현되었지만 윈도우에서는 그렇지 않습니다. 
 
+   ```json
+   "debuggers": [{
+       "type": "mono",
+       "program": "./bin/monoDebug.exe",
+       "osx": {
+           "runtime": "mono"
+       },
+       "linux": {
+           "runtime": "mono"
+       }
+   }]
+   ```
+
 <!--
-1. A combination of both approaches is possible too. The following example is from the Mono DA which is implemented as a mono application that needs a runtime on macOS and Linux but not on Windows: -->
+1. If the program is implemented in a platform independent way, e.g. as program that runs on a runtime that is available on all supported platforms, you can specify this runtime via the **runtime** attribute. As of today, VS Code supports `node` and `mono` runtimes. Our Mock debug adapter from above uses this approach.
+
+1. If your DA implementation needs different executables on different platforms, the **program** attribute can be qualified for specific platforms like this:
+
+   ```json
+   "debuggers": [{
+       "type": "gdb",
+       "windows": {
+           "program": "./bin/gdbDebug.exe",
+       },
+       "osx": {
+           "program": "./bin/gdbDebug.sh",
+       },
+       "linux": {
+           "program": "./bin/gdbDebug.sh",
+       }
+   }]
+   ```
+
+1. A combination of both approaches is possible too. The following example is from the Mono DA which is implemented as a mono application that needs a runtime on macOS and Linux but not on Windows:
 
    ```json
    "debuggers": [{
@@ -488,6 +514,7 @@ Since VS Code runs on different platforms, we have to make sure that the DA prog
        }
    }]
    ```
+-->
 
 **configurationAttributes**는 이 디버거에 사용 가능한 `launch.json`속성의 schema를 선언합니다. 이 schema는 `launch.json`을 검증하고, IntelliSense를 지원하고, 설정 구성을 수정할 때 호버링 도움말을 지원할때 사용됩니다.
 

--- a/api/extension-guides/icon-theme.md
+++ b/api/extension-guides/icon-theme.md
@@ -93,6 +93,7 @@ The following properties are supported: -->
 - `fontColor`: 글리프 폰트를 사용하는 경우: 글리프의 색상을 지정합니다.
 - `fontSize`: 폰트를 사용하는 경우: 폰트의 크기이며, 폰트에서 지정하는 값이 기본값입니다. 부모 폰트 사이즈를 기준으로 상대 값을 가져야 합니다(예 150%)
 - `fontId`: 폰트를 사용하는 경우: 폰트의 식별자입니다. 지정되지 않았다면, 폰트 지정 섹션의 첫번째 폰트가 사용됩니다. 
+
 <!--
 - `iconPath`: When using a svg/png: the path to the image.
 - `fontCharacter`: When using a glyph font: The character in the font to use.

--- a/api/extension-guides/task-provider.md
+++ b/api/extension-guides/task-provider.md
@@ -15,7 +15,7 @@ description: ""
 <!--
 Users normally define [tasks](/docs/editor/tasks) in Visual Studio Code in a `tasks.json` file. However, there are some tasks during software development that can be automatically detected by a VS Code extension with a Task Provider. When the **Tasks: Run Task** command is run from VS Code, all active Task Providers contribute tasks that the user can run. While the `tasks.json` file lets the user manually define a task for a specific folder or workspace, a Task Provider can detect details about a workspace and then automatically create a corresponding VS Code Task. For example, a Task Provider could check if there is a specific build file, such as `make` or `Rakefile`, and create a build task. This topic describes how extensions can auto-detect and provide tasks to end-users. -->
 
-이 가이드는 여러분에게 [Rakefiles]에 정의되어 있는 작업을 자동으로 감지하는  작업 제공자를 만드는 방법을 가르칩니다. 완전한 소스코드는 이곳에 있습니다: https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample
+이 가이드는 여러분에게 [Rakefiles]에 정의되어 있는 작업을 자동으로 감지하는  작업 제공자를 만드는 방법을 가르칩니다. 완전한 소스코드는 이곳에 있습니다: [https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample)
 
 <!--
 This guide teaches you how to build a Task Provider that auto-detects tasks defined in [Rakefiles](https://ruby.github.io/rake/). The complete source code is at: https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample. -->
@@ -167,7 +167,7 @@ return new vscode.Task(definition, vscode.TaskScope.Workspace, `${flavor} ${flag
   }));
 ```
 
-`Pseudoterminal`의 구현을 포함한 완전한 예시는 https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample/src/customTaskProvider.ts 에 있습니다. 
+`Pseudoterminal`의 구현을 포함한 완전한 예시는 [https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample/src/customTaskProvider.ts](https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample/src/customTaskProvider.ts) 에 있습니다. 
 
 <!--
 The full example, including the implementation of `Pseudoterminal` is at https://github.com/Microsoft/vscode-extension-samples/tree/master/task-provider-sample/src/customTaskProvider.ts -->

--- a/api/extension-guides/tree-view.md
+++ b/api/extension-guides/tree-view.md
@@ -10,7 +10,7 @@ description: ""
 <!-- 
 # Tree View Guide -->
 
-이번 가이드에서는 Visual Studio Code에 뷰 컨테이너와 트리 뷰를 사용하는 익스텐션을 작성하는 방법을 설명할 것입니다. 여러분은 소스 코드를 포함한 예시 익스텐션을 여기서 확인 할 수 있습니다 : https://github.com/Microsoft/vscode-extension-samples/tree/master/tree-view-sample.
+이번 가이드에서는 Visual Studio Code에 뷰 컨테이너와 트리 뷰를 사용하는 익스텐션을 작성하는 방법을 설명할 것입니다. 여러분은 소스 코드를 포함한 예시 익스텐션을 여기서 확인 할 수 있습니다 : [https://github.com/Microsoft/vscode-extension-samples/tree/master/tree-view-sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/tree-view-sample).
 
 <!-- This guide teaches you how to write an extension that contributes view containers and tree views to Visual Studio Code. You can find a sample extension with source code at: https://github.com/Microsoft/vscode-extension-samples/tree/master/tree-view-sample. -->
 

--- a/api/extension-guides/tree-view.md
+++ b/api/extension-guides/tree-view.md
@@ -60,7 +60,7 @@ To contribute a View Container, you should first register it using [`contributes
 <!--
 ## Tree View -->
 
-뷰는 뷰 컨테이너 내부에서 보여지는 UI 를 지칭합니다. [`contributes.views`](/api/references/contribution-points#contributes.views) Contribution Point 를 통해 여러분은 새로운 뷰를 빌트인 혹은 작성한 뷰 컨테이너에 더할 수 있습니다.
+뷰는 뷰 컨테이너 내부에서 보여지는 UI 를 지칭합니다. [`contributes.views`](/api/references/contribution-points#contributes.views) Contribution Point를 통해 여러분은 새로운 뷰를 빌트인 혹은 작성한 뷰 컨테이너에 더할 수 있습니다.
 
 <!--
 A view is an UI section that is shown inside the View Container. With the [`contributes.views`](/api/references/contribution-points#contributes.views) Contribution Point, you can add new views to the built-in or contributed View Containers. -->

--- a/api/extension-guides/virtual-documents.md
+++ b/api/extension-guides/virtual-documents.md
@@ -10,7 +10,7 @@ description: ""
 
 <!--# Virtual Documents -->
 
-텍스트 문서 컨텐츠 제공 API는 여러분이 읽기 전용 문서를 임의의 소스로부터 Visual Studio Code를 통해 생성 할 수 있게 합니다. 소스코드가 제공된 예시 익스텐션을 여기서 확인하십시오: https://github.com/Microsoft/vscode-extension-samples/blob/master/virtual-document-sample/README.md
+텍스트 문서 컨텐츠 제공 API는 여러분이 읽기 전용 문서를 임의의 소스로부터 Visual Studio Code를 통해 생성 할 수 있게 합니다. 소스코드가 제공된 예시 익스텐션을 여기서 확인하십시오: [https://github.com/Microsoft/vscode-extension-samples/blob/master/virtual-document-sample/README.md](https://github.com/Microsoft/vscode-extension-samples/blob/master/virtual-document-sample/README.md)
 
 <!--
 The text document content provider API allows you to create readonly documents in Visual Studio Code from arbitrary sources. You can find a sample extension with source code at: https://github.com/Microsoft/vscode-extension-samples/blob/master/virtual-document-sample/README.md-->
@@ -104,7 +104,7 @@ const myProvider = class implements vscode.TextDocumentContentProvider {
 <!--
 The event emitter has a `fire` method which is can be used to notify VS Code when a change has happened in a document. The document which has changed is identified by its uri given as argument to the `fire` method. The provider will then be called again to provide the updated content, assuming the document is still open. -->
 
-이것이 VS Code 가 가상 문서에서 변경을 감지하기위해 필요한 전부 입니다. 이 기능을 사용한 더 복잡한 예시를 이곳에서 참조하십시오 : https://github.com/Microsoft/vscode-extension-samples/blob/master/contentprovider-sample/README.md
+이것이 VS Code 가 가상 문서에서 변경을 감지하기위해 필요한 전부 입니다. 이 기능을 사용한 더 복잡한 예시를 이곳에서 참조하십시오 : [https://github.com/Microsoft/vscode-extension-samples/blob/master/contentprovider-sample/README.md](https://github.com/Microsoft/vscode-extension-samples/blob/master/contentprovider-sample/README.md)
 
 <!--
 That's all what's needed to make VS Code listen for changes of virtual document. To see a more complex example making use of this feature, look at: https://github.com/Microsoft/vscode-extension-samples/blob/master/contentprovider-sample/README.md -->

--- a/api/extension-guides/webview.md
+++ b/api/extension-guides/webview.md
@@ -27,6 +27,7 @@ Think of a webview as an `iframe` within VS Code that your extension controls. A
 ## Links-->
 
 - [웹 뷰 예제](https://github.com/Microsoft/vscode-extension-samples/blob/master/webview-sample/README.md)
+
 <!--
 - [Webview Sample](https://github.com/Microsoft/vscode-extension-samples/blob/master/webview-sample/README.md) -->
 
@@ -497,6 +498,7 @@ function updateWebviewForCat(panel: vscode.WebviewPanel, catName: keyof typeof c
 ![Responding to onDidChangeViewState events](images/webview/basics-ondidchangeviewstate.gif)
 
 웹 뷰 검토 및 디버그
+
 <!-- 
 ### Inspecting and debugging webviews-->
 

--- a/api/language-extensions/programmatic-language-features.md
+++ b/api/language-extensions/programmatic-language-features.md
@@ -402,6 +402,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 > **기본**
 >
 > 시그니쳐 도움말에 함수 혹은 메소드에 파라미터에 관한 문서가 포함되어있는지 확인하십시오. 
+
 <!--
 > **Basic**
 >
@@ -449,6 +450,7 @@ In the response to the `initialize` method, your language server needs to announ
 ```
 
 추가로, 언어 서버는 `textDocument/definition` 요청에 응답하여야 합니다. 
+
 <!--
 In addition, your language server needs to respond to the `textDocument/definition` request. -->
 
@@ -635,6 +637,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 > **고급**
 >
 > 추가 될 것이 없습니다. 
+
 <!--
 > **Basic**
 >

--- a/api/language-extensions/snippet-guide.md
+++ b/api/language-extensions/snippet-guide.md
@@ -42,7 +42,7 @@ The [Creating snippets](https://code.visualstudio.com/docs/editor/userdefinedsni
 }
 ```
 
-완전한 소스코드를 이곳에서 확인 할 수 있습니다: https://github.com/Microsoft/vscode-extension-samples/tree/master/snippet-sample
+완전한 소스코드를 이곳에서 확인 할 수 있습니다: [https://github.com/Microsoft/vscode-extension-samples/tree/master/snippet-sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/snippet-sample)
 
 <!--
 You can find the complete source code at: https://github.com/Microsoft/vscode-extension-samples/tree/master/snippet-sample-->

--- a/api/language-extensions/syntax-highlight-guide.md
+++ b/api/language-extensions/syntax-highlight-guide.md
@@ -394,7 +394,6 @@ Grammar자체는 최상위 `injectionSelector`를 제외하면 표준 TextMate g
 <!--
 The grammar itself is a standard TextMate grammar except for the top level `injectionSelector` entry. The `injectionSelector` is a scope selector that specifies which scopes the injected grammar should be applied in. For our example, we want to highlight the word `TODO` in all `//` comments. Using the [scope inspector](#scope-inspector), we find that JavaScript's double slash comments have the scope `comment.line.double-slash`, so our injection selector is `L:comment.line.double-slash`: -->
 
-The grammar itself is a standard TextMate grammar except for the top level `injectionSelector` entry. The `injectionSelector` is a scope selector that specifies which scopes the injected grammar should be applied in. For our example, we want to highlight the word `TODO` in all `//` comments. Using the [scope inspector](#scope-inspector), we find that JavaScript's double slash comments have the scope `comment.line.double-slash`, so our injection selector is `L:comment.line.double-slash`:
 
 ```json
 {

--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -249,6 +249,7 @@ export function run(): Promise<void> {
 테스트 실행 스크립트와 `*.test.js`파일들은 모두 VS Code API에 접근할 수 있습니다.
 
 여기에 실행 예제가 있습니다. ([src/test/suite/extension.test.ts](https://github.com/microsoft/vscode-extension-samples/blob/master/helloworld-test-sample/src/test/suite/extension.test.ts)):
+
 <!--
 Both the test runner script and the `*.test.js` files have access to the VS Code API.
 

--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -76,7 +76,7 @@ code \
 --extensionTestsPath=<TEST-RUNNER-SCRIPT-PATH>
 ```
 
-**테스트 스크립트** ([`src/test/runTest.ts`](https://github.com/microsoft/vscode-extension-samples/blob/master/helloworld-test-sample/src/test/runTest.ts))는 익스텐션 테스트 매개 변수와 함께 다운로드, 압축 해제, VS Code 실행을 간소화 하기 위해`vscode-test` API를 사용합니다:
+**테스트 스크립트** ([`src/test/runTest.ts`](https://github.com/microsoft/vscode-extension-samples/blob/master/helloworld-test-sample/src/test/runTest.ts))는 익스텐션 테스트 매개 변수와 함께 다운로드, 압축 해제, VS Code 실행을 간소화 하기 위해 `vscode-test` API를 사용합니다:
 <!--
 The **test script** ([`src/test/runTest.ts`](https://github.com/microsoft/vscode-extension-samples/blob/master/helloworld-test-sample/src/test/runTest.ts)) uses the `vscode-test` API to simplify the process of downloading, unzipping, and launching VS Code with extension test parameters:
 -->

--- a/api/working-with-extensions/testing-extension.md
+++ b/api/working-with-extensions/testing-extension.md
@@ -21,7 +21,7 @@ Visual Studio Code supports running and debugging tests for your extension. Thes
 ## Overview
 -->
 
-_만약  당신이 `vscode`로부터 마이그레이션 했다면, [`vscode`로부터 마이그레이션 하기]를 먼저 보세요(#migrating-from-vscode)_.
+_만약  당신이 `vscode`로부터 마이그레이션 했다면, [`vscode`로부터 마이그레이션 하기](#migrating-from-vscode)를 먼저 보세요.
 
 만약 당신이 [Yeoman Generator](https://code.visualstudio.com/api/get-started/your-first-extension)를 이용해 익스텐션을 스캐폴딩 했다면, 통합 테스트는 이미 당신을 위해 만들어져 있을 것입니다.
 


### PR DESCRIPTION
UI가 깨진 것들을 고쳤습니다.

- numbered list  수정 (c4ac40a)
- Link만 있던 markdown 링크로 연결되게 수정 (6317b79)
- 주석이 보이던 문제 수정 (83dca13)
- 오타(띄어쓰기, 중복된 문장) 수정 (6f25e93)