### PR TITLE
Docs: Change selector in custom.scss

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -127,8 +127,3 @@
 //lg: $content-width + $nav-width,
 //xl: 1400px
 //);
-
-img,
-video {
-  width: 100%;
-}

--- a/_sass/vendor/normalize.scss/normalize.scss
+++ b/_sass/vendor/normalize.scss/normalize.scss
@@ -46,6 +46,11 @@ summary {
   display: block;
 }
 
+img,
+video {
+  width: 100%;
+}
+
 /**
  * 1. Correct `inline-block` display not defined in IE 8/9.
  * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "@primer/css": "^12.7.0"
   },
   "scripts": {
-    "test": "stylelint '**/*.scss'"
+    "test": "stylelint **/*.scss"
   }
 }


### PR DESCRIPTION
## issue #65 
custom.scss에는 selector가 들어갈 수 없도록 convention이 설정되어 있었습니다.
custom.scss에서 nomalize.scss로 파일을 옮겼습니다.

그리고 npm test의 script가 잘못되어 수정했습니다.